### PR TITLE
Add Qt5 V 5.2.1 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/build-*
+*.pro.user

--- a/TrackYourTime/cdatamanager.cpp
+++ b/TrackYourTime/cdatamanager.cpp
@@ -56,7 +56,7 @@ cDataManager::cDataManager():QObject()
 
     m_CurrentProfile = 0;
 
-    m_StorageFileName = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)+"/db.bin";
+    m_StorageFileName = QStandardPaths::writableLocation(QStandardPaths::DataLocation)+"/db.bin";
 
     loadPreferences();
     QDir storagePath(QFileInfo(m_StorageFileName).absolutePath());

--- a/TrackYourTime/cdatamanager.cpp
+++ b/TrackYourTime/cdatamanager.cpp
@@ -56,7 +56,11 @@ cDataManager::cDataManager():QObject()
 
     m_CurrentProfile = 0;
 
+#if (QT_VERSION < QT_VERSION_CHECK(5, 4, 0))
     m_StorageFileName = QStandardPaths::writableLocation(QStandardPaths::DataLocation)+"/db.bin";
+#else
+    m_StorageFileName = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)+"/db.bin";
+#endif
 
     loadPreferences();
     QDir storagePath(QFileInfo(m_StorageFileName).absolutePath());


### PR DESCRIPTION
Константа QStandardPaths::AppDataLocation определена только в Qt 5.4
В Kubuntu 14.04 штатно ставится Qt 5.2.1.
