### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/BUILD_README.md
+++ b/BUILD_README.md
@@ -7,26 +7,26 @@ First build TrackYourTime.pro with Qt Creator - it is a typical Qt project
 
 After building do the following:  
 
-#Windows
+# Windows
 
 Place TrackYourTime.exe in build folder, copy data folder,   
 copy platforms plugin with qwindows, copy necessary qt libs  
 Pack in compressed folder TrackYourTime_Windows.zip  
 
-#Mac OS X
+# Mac OS X
 
 Copy data into TrackYourTime.app/Contents/MacOS  
 add key LSUIElement with value 1 into TrackYourTime.app/Contents/Info.plist
 execute macdeployqt with -dmg flag(<path_to_qt/macdeployqt TrackYourTime.app -dmg>)
 Rename package to TrackYourTime_MacOSX.dmg
 
-#Linux
+# Linux
 Place TrackYourTime in build folder, 
 copy data folder, copy checksystem
 Pack into TrackYourTime_Linux.tar.gz
 
 
-#Localization  
+# Localization  
 its possible to make this work from console without QtCreator.  
 But QtCreator is simple and powerfull tool and i prefer to use it.  
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 ![App Screenshot](https://habrastorage.org/files/5ff/f5a/c1e/5fff5ac1e46949c0adf6db66d6ab82c8.png)  
 
-#[Documentation](https://github.com/Allexin/TrackYourTime/wiki/User-Manual) [[en](https://github.com/Allexin/TrackYourTime/wiki/User-Manual)|[ru](https://github.com/Allexin/TrackYourTime/wiki/%D0%A0%D1%83%D0%BA%D0%BE%D0%B2%D0%BE%D0%B4%D1%81%D1%82%D0%B2%D0%BE-%D0%BF%D0%BE%D0%BB%D1%8C%D0%B7%D0%BE%D0%B2%D0%B0%D1%82%D0%B5%D0%BB%D1%8F)]  
+# [Documentation](https://github.com/Allexin/TrackYourTime/wiki/User-Manual) [[en](https://github.com/Allexin/TrackYourTime/wiki/User-Manual)|[ru](https://github.com/Allexin/TrackYourTime/wiki/%D0%A0%D1%83%D0%BA%D0%BE%D0%B2%D0%BE%D0%B4%D1%81%D1%82%D0%B2%D0%BE-%D0%BF%D0%BE%D0%BB%D1%8C%D0%B7%D0%BE%D0%B2%D0%B0%D1%82%D0%B5%D0%BB%D1%8F)]  
 [![Join the chat at https://gitter.im/Allexin/TrackYourTime](https://badges.gitter.im/Allexin/TrackYourTime.svg)](https://gitter.im/Allexin/TrackYourTime?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)  
 
-#Downloads
+# Downloads
 [Latest Stable Version](https://github.com/Allexin/TrackYourTime/releases/tag/0.9.2)
 
-#Roadmap
+# Roadmap
 
 https://github.com/Allexin/TrackYourTime/wiki
 

--- a/README_RU.md
+++ b/README_RU.md
@@ -1,6 +1,6 @@
 # TrackYourTime 
 
-#[Документация](https://github.com/Allexin/TrackYourTime/wiki/%D0%A0%D1%83%D0%BA%D0%BE%D0%B2%D0%BE%D0%B4%D1%81%D1%82%D0%B2%D0%BE-%D0%BF%D0%BE%D0%BB%D1%8C%D0%B7%D0%BE%D0%B2%D0%B0%D1%82%D0%B5%D0%BB%D1%8F) [[en](https://github.com/Allexin/TrackYourTime/wiki/User-Manual)|[ru](https://github.com/Allexin/TrackYourTime/wiki/%D0%A0%D1%83%D0%BA%D0%BE%D0%B2%D0%BE%D0%B4%D1%81%D1%82%D0%B2%D0%BE-%D0%BF%D0%BE%D0%BB%D1%8C%D0%B7%D0%BE%D0%B2%D0%B0%D1%82%D0%B5%D0%BB%D1%8F)]  
+# [Документация](https://github.com/Allexin/TrackYourTime/wiki/%D0%A0%D1%83%D0%BA%D0%BE%D0%B2%D0%BE%D0%B4%D1%81%D1%82%D0%B2%D0%BE-%D0%BF%D0%BE%D0%BB%D1%8C%D0%B7%D0%BE%D0%B2%D0%B0%D1%82%D0%B5%D0%BB%D1%8F) [[en](https://github.com/Allexin/TrackYourTime/wiki/User-Manual)|[ru](https://github.com/Allexin/TrackYourTime/wiki/%D0%A0%D1%83%D0%BA%D0%BE%D0%B2%D0%BE%D0%B4%D1%81%D1%82%D0%B2%D0%BE-%D0%BF%D0%BE%D0%BB%D1%8C%D0%B7%D0%BE%D0%B2%D0%B0%D1%82%D0%B5%D0%BB%D1%8F)]  
 [![Чат на https://gitter.im/Allexin/TrackYourTime](https://badges.gitter.im/Allexin/TrackYourTime.svg)](https://gitter.im/Allexin/TrackYourTime?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)  
 
 # Загрузка


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
