### PR TITLE
added check for nullptr in mac string conversion

### DIFF
--- a/TrackYourTime/tools/os_api.cpp
+++ b/TrackYourTime/tools/os_api.cpp
@@ -399,7 +399,7 @@ QString uniCFStrToQStr(const CFStringRef cfString)
 {
     QChar qchar;
     QString qString("");
-    int lenCF=(int)CFStringGetLength(cfString);  // возвращает длину строки
+    int lenCF=cfString != nullptr ? (int)CFStringGetLength(cfString): 0;  // возвращает длину строки
     for (int i=0;i<lenCF;i++)
     {
         qchar=((ushort)CFStringGetCharacterAtIndex(cfString,(CFIndex)i));  // получает символ из строки


### PR DESCRIPTION
Got a seg fault when a window didn't have a title #80
