### PR TITLE
Json store and load

### DIFF
--- a/TrackYourTime/data/cdatamanager.cpp
+++ b/TrackYourTime/data/cdatamanager.cpp
@@ -103,7 +103,7 @@ cDataManager::~cDataManager()
 const sProfile *cDataManager::profiles(int index)
 {
     if (index<0 || index>=m_Profiles.size())
-        return NULL;
+        return nullptr;
     return &m_Profiles[index];
 }
 
@@ -459,7 +459,7 @@ void cDataManager::saveDB()
         file.writeInt(m_Categories.size());
         for (int i = 0; i<m_Categories.size(); i++){
             file.writeString(m_Categories[i].name);
-            file.writeInt(m_Categories[i].color.rgba());
+            file.writeUint(m_Categories[i].color.rgba());
         }
 
         //applications
@@ -535,7 +535,7 @@ void cDataManager::loadDB()
                 m_Categories.resize(file.readInt());
                 for (int i = 0; i<m_Categories.size(); i++){
                     m_Categories[i].name = file.readString();
-                    m_Categories[i].color = QColor::fromRgba(file.readInt());
+                    m_Categories[i].color = QColor::fromRgba(file.readUint());
                 }
 
                 //applications
@@ -544,7 +544,7 @@ void cDataManager::loadDB()
                     m_Applications[i] = new sAppInfo();
                     m_Applications[i]->visible = file.readInt()==1;
                     m_Applications[i]->path = file.readString();
-                    m_Applications[i]->trackerType = (sAppInfo::eTrackerType)file.readInt();                    
+                    m_Applications[i]->trackerType = static_cast<sAppInfo::eTrackerType>(file.readInt());
                     m_Applications[i]->useCustomScript = file.readInt()==1;
                     m_Applications[i]->customScript = file.readString();
 
@@ -596,7 +596,7 @@ void cDataManager::loadPreferences()
     m_ClientMode = settings.db()->value(CONF_CLIENT_MODE_ID,m_ClientMode).toBool();
     m_ClientModeHost = settings.db()->value(CONF_CLIENT_MODE_HOST_ID,m_ClientModeHost).toString();
 
-    m_BackupDelay = (eBackupDelay)settings.db()->value(CONF_BACKUP_DELAY_ID,BD_ONE_WEEK).toInt();
+    m_BackupDelay = static_cast<eBackupDelay>(settings.db()->value(CONF_BACKUP_DELAY_ID,BD_ONE_WEEK).toInt());
     m_BackupFolder = settings.db()->value(CONF_BACKUP_FILENAME_ID,m_BackupFolder).toString();
 
     if (!m_StorageFileName.isEmpty()){
@@ -646,7 +646,7 @@ sAppInfo::sAppInfo(QString name, int profilesCount)
 
 sAppInfo::sAppInfo()
 {
-    predefinedInfo = NULL;
+    predefinedInfo = nullptr;
 }
 
 sAppInfo::~sAppInfo()

--- a/TrackYourTime/data/cdatamanager.h
+++ b/TrackYourTime/data/cdatamanager.h
@@ -159,6 +159,9 @@ protected:
     int getActivityIndexDirect(int appIndex, QString activityName);
     void saveDB();
     void loadDB();
+    void saveJSON();
+    void loadJSON();
+
     void loadPreferences();
 public:
     cDataManager();

--- a/TrackYourTime/tools/cfilebin.cpp
+++ b/TrackYourTime/tools/cfilebin.cpp
@@ -21,14 +21,14 @@
 int cFileBin::readInt()
 {
     int value;
-    read((char*)&value,sizeof(int));
+    read(reinterpret_cast<char*>(&value), sizeof(int));
     return value;
 }
 
 uint cFileBin::readUint()
 {
     uint value;
-    read((char*)&value,sizeof(uint));
+    read(reinterpret_cast<char*>(&value), sizeof(uint));
     return value;
 }
 
@@ -61,12 +61,12 @@ QString cFileBin::readUtf8Line()
 
 void cFileBin::writeInt(int value)
 {
-    write((char*)&value,sizeof(int));
+    write(reinterpret_cast<char*>(&value), sizeof(int));
 }
 
 void cFileBin::writeUint(uint value)
 {
-    write((char*)&value,sizeof(uint));
+    write(reinterpret_cast<char*>(&value), sizeof(uint));
 }
 
 void cFileBin::writeString(const QString &value)

--- a/TrackYourTime/ui/settingswindow.h
+++ b/TrackYourTime/ui/settingswindow.h
@@ -40,7 +40,7 @@ protected:
     QString getDefaultMessage();
 public:
     explicit SettingsWindow(cDataManager* DataManager);
-    ~SettingsWindow();
+    ~SettingsWindow() override;
 
 private:
     Ui::SettingsWindow *ui;

--- a/TrackYourTime/ui/settingswindow.ui
+++ b/TrackYourTime/ui/settingswindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>578</width>
-    <height>606</height>
+    <height>790</height>
    </rect>
   </property>
   <property name="sizePolicy">


### PR DESCRIPTION
Пока реализовал отдельными функциями.
Qt поддерживает как стандартный json, так и его бинарный аналог.
Так что можно попве заменить штатные функции сохранения/восстановления на json добавив параметр в конфиг - сохранять в бинарном или в текстовом виде.
В бинарном - компактно, в текстовом - удобно для дальнейшей интеграции.